### PR TITLE
Update Linked Tables to allow Link Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LO5R Backend Server
+# LO5R Backend Server v1.3.1
 
 This navigates the backend interactions with the database for the [lo5r-app front end](https://github.com/sachieko/lo5r-app) using Typescript and an Express server with Postgres SQL.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lo5r-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lo5r-backend",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "chalk": "^4.1.2",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lo5r-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "src/application.js",
   "scripts": {
     "dev": "npx tsc && node build/application.js",

--- a/src/queries/armorQueries.ts
+++ b/src/queries/armorQueries.ts
@@ -1,6 +1,6 @@
 export const armorsQuery = `
   SELECT armors.id, armors.name AS title, armors.physical_resistance, armors.supernatural_resistance, armors.rarity,
-  armors.cost, armors.book, armors.pg, STRING_AGG(item_qualities.title, ', ') as qualities
+  armors.cost, armors.book, armors.pg, STRING_AGG('[' || item_qualities.title || ']', ', ') as qualities
   FROM armors
   LEFT JOIN armor_qualities ON armors.id = armor_qualities.armor_id
   LEFT JOIN item_qualities ON item_qualities.id = armor_qualities.quality_id
@@ -10,7 +10,7 @@ export const armorsQuery = `
 
 export const armorsIdQuery = `
   SELECT armors.id, armors.name AS title, armors.physical_resistance, armors.supernatural_resistance, armors.rarity,
-  armors.cost, armors.book, armors.pg, STRING_AGG(item_qualities.title, ', ') as qualities
+  armors.cost, armors.book, armors.pg, STRING_AGG('[' || item_qualities.title || ']', ', ') as qualities
   FROM armors
   LEFT JOIN armor_qualities ON armors.id = armor_qualities.armor_id
   LEFT JOIN item_qualities ON item_qualities.id = armor_qualities.quality_id

--- a/src/queries/opportunityQueries.ts
+++ b/src/queries/opportunityQueries.ts
@@ -1,12 +1,12 @@
 export const opportunitiesQuery = `
-  SELECT opportunities.*, techniques.name, techniques.prerequisite, techniques.rank,
+  SELECT opportunities.*, '[' || techniques.name || ']', techniques.prerequisite, techniques.rank,
   techniques.type, techniques.description, techniques.activation, techniques.effect AS technique_effect
   FROM opportunities
   LEFT JOIN techniques ON technique_id = techniques.id
   ORDER BY opportunities.ring, opportunities.category, opportunities.id;`;
 
 export const opportunityQuery = `
-  SELECT opportunities.*, techniques.name, techniques.prerequisite, techniques.rank,
+  SELECT opportunities.*, '[' || techniques.name || ']', techniques.prerequisite, techniques.rank,
   techniques.type, techniques.description, techniques.activation, techniques.effect AS technique_effect
   FROM opportunities
   LEFT JOIN techniques ON technique_id = techniques.id

--- a/src/queries/weaponQueries.ts
+++ b/src/queries/weaponQueries.ts
@@ -1,6 +1,6 @@
 export const weaponsQuery = `
   SELECT weapons.id, weapons.name as title, weapons.type, weapons.skill, weapons.range, weapons.damage, weapons.deadliness,weapons.rarity,
-  weapons.cost, weapons.book, weapons.pg, STRING_AGG(item_qualities.title, ', ') as qualities
+  weapons.cost, weapons.book, weapons.pg, STRING_AGG('[' || item_qualities.title || ']', ', ') as qualities
   FROM weapons
   LEFT JOIN weapon_qualities ON weapons.id = weapon_qualities.weapon_id
   LEFT JOIN item_qualities ON item_qualities.id = weapon_qualities.quality_id
@@ -10,7 +10,7 @@ export const weaponsQuery = `
 
 export const weaponsIdQuery = `
   SELECT weapons.id, weapons.name as title, weapons.type, weapons.skill, weapons.range, weapons.damage, weapons.deadliness,weapons.rarity,
-  weapons.cost, weapons.book, weapons.pg, STRING_AGG(item_qualities.title, ', ') as qualities
+  weapons.cost, weapons.book, weapons.pg, STRING_AGG('[' || item_qualities.title || ']', ', ') as qualities
   FROM weapons
   LEFT JOIN weapon_qualities ON weapons.id = weapon_qualities.weapon_id
   LEFT JOIN item_qualities ON item_qualities.id = weapon_qualities.quality_id


### PR DESCRIPTION
Tables that reference values in other tables now automatically return those linked values surrounded by Square Brackets [ ] to comply with new opinionated link parsing for the front-end.